### PR TITLE
Updates Playwright base image to 1.58.0 to resolve browser executable mismatch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM mcr.microsoft.com/playwright/python:v1.40.0-jammy
-
+FROM mcr.microsoft.com/playwright/python:v1.58.0-jammy
 WORKDIR /app
 
 # Install dependencies


### PR DESCRIPTION
 Gemini said

The logs indicate a version mismatch between the Playwright library installed via pip and the system-level browser binaries provided by your Docker base image.

The Problem

Your Dockerfile uses an older base image, but your requirements.txt allowed pip to install the latest version of the Playwright library (1.58.0). Because Playwright libraries are tightly coupled with specific browser versions, the new library is looking for a browser executable that doesn't exist in your 1.40.0 container.

The Fix

Update your Dockerfile to use the base image that matches your library version.

    Modify your Dockerfile: Change the FROM line to match the required version.